### PR TITLE
IS-1080 - holiday-provider lib version as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "7.1 - 8.0",
-        "pilulka-distribuce/holiday-provider": "^0.1"
+        "pilulka-distribuce/holiday-provider": "^0.1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "pilulka-distribuce/holiday-provider",
-            "version": "v0.1.3",
+            "version": "v0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PilulkaDistribuce/holiday-provider.git",
-                "reference": "71a6d8eea0bdd26bb844218b968915a81ca84093"
+                "reference": "b5a22e814c6f31da60454137c5668703ce2d8b99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PilulkaDistribuce/holiday-provider/zipball/71a6d8eea0bdd26bb844218b968915a81ca84093",
-                "reference": "71a6d8eea0bdd26bb844218b968915a81ca84093",
+                "url": "https://api.github.com/repos/PilulkaDistribuce/holiday-provider/zipball/b5a22e814c6f31da60454137c5668703ce2d8b99",
+                "reference": "b5a22e814c6f31da60454137c5668703ce2d8b99",
                 "shasum": ""
             },
             "require": {
@@ -41,9 +41,9 @@
             "description": "Provides holiday for various countries",
             "support": {
                 "issues": "https://github.com/PilulkaDistribuce/holiday-provider/issues",
-                "source": "https://github.com/PilulkaDistribuce/holiday-provider/tree/v0.1.3"
+                "source": "https://github.com/PilulkaDistribuce/holiday-provider/tree/v0.1.4"
             },
-            "time": "2021-09-24T07:30:08+00:00"
+            "time": "2021-09-30T12:36:27+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5efc15b7298227e7e31ada425295ebff",
+    "content-hash": "2995f68a99baf6f1dba9659a28a4f780",
     "packages": [
         {
             "name": "pilulka-distribuce/holiday-provider",
-            "version": "v0.1.4",
+            "version": "0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PilulkaDistribuce/holiday-provider.git",
@@ -513,16 +513,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.98",
+            "version": "0.12.99",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "3bb7cc246c057405dd5e290c3ecc62ab51d57e00"
+                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3bb7cc246c057405dd5e290c3ecc62ab51d57e00",
-                "reference": "3bb7cc246c057405dd5e290c3ecc62ab51d57e00",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4d40f1d759942f523be267a1bab6884f46ca3f7",
+                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7",
                 "shasum": ""
             },
             "require": {
@@ -553,7 +553,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.98"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.99"
             },
             "funding": [
                 {
@@ -573,7 +573,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-02T12:33:01+00:00"
+            "time": "2021-09-12T20:09:55+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1569,7 +1569,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {


### PR DESCRIPTION
was ^0.1 but release tags had v prefix - like v0.1.4 which is bullshit, it has to be version string like 0.1.5 so ^0.1.5 in composer.lock can work